### PR TITLE
Uvolnění závislosti na PayPal knihovně

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,8 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - hhvm
-
-matrix:
-  allow_failures:
-    - php: 7.2
-    - php: hhvm
+  - 7.3
+  - 7.4
 
 before_script:
   # Update composer

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
     "php": ">=5.6.0",
     "nette/di": "^2.4",
     "nette/application": "^2.4",
-    "paypal/rest-api-sdk-php": "1.5.*"
+    "paypal/rest-api-sdk-php": "^1.5"
   },
   "require-dev": {
-    "nette/bootstrap": "^2.4@dev",
-    "nette/robot-loader": "^2.4@dev",
-    "nette/tester": "^1.7@dev",
-    "mockery/mockery": "^0.9@dev"
+    "nette/bootstrap": "^2.4",
+    "nette/robot-loader": "^2.4",
+    "nette/tester": "^2.4",
+    "mockery/mockery": "^1.4"
   },
   "autoload": {
     "psr-0": {


### PR DESCRIPTION
- uvolněna závislost na paypal/rest-api-sdk-php (changelog nenaznačuje žádné BC breaky, snad dodržují semver 🤞)
- aktualizovány dev závislosti
- travis testy pouze na aktuálních verzích PHP (zachována restrikce v composeru, pouze netestuje starší verze, které by se stejně neměly používat)